### PR TITLE
Disable linter

### DIFF
--- a/chapter-05/build.sbt
+++ b/chapter-05/build.sbt
@@ -12,7 +12,6 @@ scalacOptions ++= Seq(
   "-language:implicitConversions",
   "-language:postfixOps",
   "-Ywarn-dead-code",
-  "-Xlint",
   "-Xfatal-warnings"
   )
 


### PR DESCRIPTION
Using `-Xlint` leads to
```
# baidarov @ 77 in ~/study/essential-slick-code/chapter-05 on git:3.2 x [20:34:37] C:130
$ sbt
[info] Loading project definition from /Users/baidarov/study/essential-slick-code/chapter-05/project
[info] Loading settings from build.sbt ...
[info] Set current project to essential-slick-chapter-05 (in build file:/Users/baidarov/study/essential-slick-code/chapter-05/)
[info] sbt server started at 127.0.0.1:4530
sbt:essential-slick-chapter-05> console
[info] Starting scala interpreter...
Welcome to Scala 2.12.3 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_161).
Type in expressions for evaluation. Or try :help.

scala> <console>:11: warning: Unused import
       import org.joda.time._
                            ^
<console>:12: warning: Unused import
       import scala.concurrent.ExecutionContext.Implicits.global
                                                          ^
<console>:19: warning: Unused import
       import PKs._
                  ^
error: No warnings can be incurred under -Xfatal-warnings.
Interpreter encountered errors during initialization!

[error] (Thread-2) java.lang.InterruptedException
[error] java.lang.InterruptedException
[error] 	at java.util.concurrent.SynchronousQueue.put(SynchronousQueue.java:879)
[error] 	at scala.tools.nsc.interpreter.SplashLoop.run(InteractiveReader.scala:81)
[error] 	at java.lang.Thread.run(Thread.java:748)

[success] Total time: 14 s, completed Jun 23, 2018 8:35:04 PM
```

Since other chapters do not use this option, I simply remove it.